### PR TITLE
Misc extension for dexon usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Arbitrary-precision fixed-point decimal numbers in go.
 
 NOTE: can "only" represent numbers with a maximum of 2^31 digits after the decimal point.
 
+## THIS IS UNSTABLE BRANCH
+master branch is under development. API changes can be introduced any time. If
+you are seeking a stable version, please access v1.x tags.
+
 ## Features
 
  * the zero-value is 0, and is safe to use without initialization

--- a/decimal.go
+++ b/decimal.go
@@ -344,6 +344,14 @@ func NewFromFloatWithExponent(value float64, exp int32) Decimal {
 	}
 }
 
+// Rescale returns a rescaled version of the decimal. Returned
+// decimal may be less precise if the given exponent is bigger
+// than the initial exponent of the Decimal.
+// NOTE: this will truncate, NOT round
+func (d Decimal) Rescale(exp int32) Decimal {
+	return d.rescale(exp)
+}
+
 // rescale returns a rescaled version of the decimal. Returned
 // decimal may be less precise if the given exponent is bigger
 // than the initial exponent of the Decimal.

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,40 @@
+package decimal
+
+import "fmt"
+
+// ErrorExponentLimit is returned when the decimal exponent exceed int32 range.
+type ErrorExponentLimit struct {
+	value string
+}
+
+// Error implements error interface.
+func (e *ErrorExponentLimit) Error() string {
+	return fmt.Sprintf("can't convert %s to decimal: fractional part too long", e.value)
+}
+
+// ErrorInvalidFormat is returned when the input string is not valid integer.
+type ErrorInvalidFormat struct {
+	reason string
+}
+
+// Error implements error interface.
+func (e *ErrorInvalidFormat) Error() string {
+	return e.reason
+}
+
+// ErrorInvalidType is returned when the value passed into sql.Scanner is not
+// with expected type. (valid types: int64, float64, []byte, string)
+type ErrorInvalidType struct {
+	reason string
+}
+
+// Error implements error interface.
+func (e *ErrorInvalidType) Error() string {
+	return e.reason
+}
+
+func assertErrorInterface() {
+	var _ error = (*ErrorExponentLimit)(nil)
+	var _ error = (*ErrorInvalidFormat)(nil)
+	var _ error = (*ErrorInvalidType)(nil)
+}


### PR DESCRIPTION
1. export rescale as dexon needs the coefficient big.Int at specific exponent.
2. wrap errors so that caller can identify them.