### PR TITLE
tuning rescale performance

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -386,14 +386,15 @@ func (d Decimal) Rescale(exp int32) Decimal {
 //
 func (d Decimal) rescale(exp int32) Decimal {
 	d.ensureInitialized()
-	// NOTE(vadim): must convert exps to float64 before - to prevent overflow
-	diff := math.Abs(float64(exp) - float64(d.exp))
+	// NOTE: convert exps to int64 before - to prevent overflow
+	diff := int64(exp) - int64(d.exp)
 	value := new(big.Int).Set(d.value)
 
-	expScale := new(big.Int).Exp(tenInt, big.NewInt(int64(diff)), nil)
 	if exp > d.exp {
+		expScale := new(big.Int).Exp(tenInt, big.NewInt(diff), nil)
 		value = value.Quo(value, expScale)
 	} else if exp < d.exp {
+		expScale := new(big.Int).Exp(tenInt, big.NewInt(-diff), nil)
 		value = value.Mul(value, expScale)
 	}
 


### PR DESCRIPTION
Rescale is used in most operations and some of them often have the scale
unchanged. e.g. In Add or Sub, one out of two rescale will always do no
change. Save one big.Int.Exp in this case.